### PR TITLE
Refactor Portal defaults to config

### DIFF
--- a/config/ninjaportal.php
+++ b/config/ninjaportal.php
@@ -46,6 +46,20 @@ return [
         ],
     ],
 
+    'user' => [
+        'statuses' => [
+            'active',
+            'inactive',
+            'pending',
+        ],
+        'default_status' => env('NINJAPORTAL_USER_DEFAULT_STATUS', 'pending'),
+    ],
+
+    'api_products' => [
+        'default_visibility' => env('NINJAPORTAL_API_PRODUCT_DEFAULT_VISIBILITY', 'public'),
+        'storage_disk' => env('NINJAPORTAL_API_PRODUCT_STORAGE_DISK', 'public'),
+    ],
+
     'models' => [
         'Admin' => \NinjaPortal\Portal\Models\Admin::class,
         'ApiProduct' => \NinjaPortal\Portal\Models\ApiProduct::class,

--- a/database/migrations/2024_03_18_014146_create_users_table.php
+++ b/database/migrations/2024_03_18_014146_create_users_table.php
@@ -30,9 +30,9 @@ return new class extends Migration
                 $table->string('password');
 
             if (! Schema::hasColumn('users', 'status'))
-                $table->string('status')->default(User::$ACTIVE_STATUS);
+                $table->string('status')->default(config('ninjaportal.user.default_status', User::defaultStatus()));
 
-            if (! Schema::hasColumn('users', 'role'))
+            if (! Schema::hasColumn('users', 'sync_with_apigee'))
                 $table->boolean('sync_with_apigee')->default(false);
 
             if (! Schema::hasColumn('users', 'custom_attributes'))

--- a/database/migrations/2024_03_21_023911_create_api_products_table.php
+++ b/database/migrations/2024_03_21_023911_create_api_products_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
             $table->string('slug')->unique();
             $table->string('apigee_product_id')->index();
             $table->string('swagger_url')->nullable();
-            $table->string('visibility')->default('public');
+            $table->string('visibility')->default(config('ninjaportal.api_products.default_visibility', \NinjaPortal\Portal\Models\ApiProduct::defaultVisibility()));
             $table->timestamps();
         });
     }

--- a/database/migrations/2026_01_16_010000_update_users_status_default_to_pending.php
+++ b/database/migrations/2026_01_16_010000_update_users_status_default_to_pending.php
@@ -14,7 +14,7 @@ return new class extends Migration
         }
 
         // Avoid Schema::change() (requires doctrine/dbal). Use raw SQL instead.
-        DB::statement("ALTER TABLE `users` MODIFY `status` VARCHAR(255) NOT NULL DEFAULT '".User::$DEFAULT_STATUS."'");
+        DB::statement("ALTER TABLE `users` MODIFY `status` VARCHAR(255) NOT NULL DEFAULT '".config('ninjaportal.user.default_status', User::defaultStatus())."'");
     }
 
     public function down(): void
@@ -23,7 +23,7 @@ return new class extends Migration
             return;
         }
 
-        DB::statement("ALTER TABLE `users` MODIFY `status` VARCHAR(255) NOT NULL DEFAULT '".User::$ACTIVE_STATUS."'");
+        DB::statement("ALTER TABLE `users` MODIFY `status` VARCHAR(255) NOT NULL DEFAULT '".User::activeStatus()."'");
     }
 };
 

--- a/src/Models/ApiProduct.php
+++ b/src/Models/ApiProduct.php
@@ -13,17 +13,6 @@ class ApiProduct extends Model
 {
     use HasTranslations;
 
-    /**
-     * used for storing the swagger file in the storage
-     */
-    public static string $STORAGE_DISK = 'public';
-
-    public static array $VISIBILITY = [
-        'public' => 'public',
-        'private' => 'private',
-        'draft' => 'draft',
-    ];
-
     protected $fillable = [
         'slug',
         'swagger_url',
@@ -59,5 +48,30 @@ class ApiProduct extends Model
     public function scopeFilter(Builder $builder): Builder
     {
         return (new ApiProductFilter)->apply($builder);
+    }
+
+    public static function visibilities(): array
+    {
+        return [
+            'public',
+            'private',
+            'draft',
+        ];
+    }
+
+    public static function defaultVisibility(): string
+    {
+        $configured = strtolower(trim((string) config('ninjaportal.api_products.default_visibility', 'public')));
+
+        return in_array($configured, static::visibilities(), true)
+            ? $configured
+            : 'public';
+    }
+
+    public static function storageDisk(): string
+    {
+        $disk = trim((string) config('ninjaportal.api_products.storage_disk', 'public'));
+
+        return $disk !== '' ? $disk : 'public';
     }
 }

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -14,18 +14,6 @@ class User extends Authenticatable
 {
     use HasFactory, Notifiable;
 
-    public static string $ACTIVE_STATUS = 'active';
-
-    public static string $INACTIVE_STATUS = 'inactive';
-
-    public static string $DEFAULT_STATUS = 'pending';
-
-    public static array $USER_STATUS = [
-        'active' => 'active',
-        'inactive' => 'inactive',
-        'pending' => 'pending',
-    ];
-
     protected $fillable = [
         'first_name',
         'last_name',
@@ -76,5 +64,37 @@ class User extends Authenticatable
     public function scopeFilter(Builder $builder): Builder
     {
         return (new UserFilter)->apply($builder);
+    }
+
+    public static function statuses(): array
+    {
+        $statuses = config('ninjaportal.user.statuses', ['active', 'inactive', 'pending']);
+
+        return array_values(array_filter(array_map(
+            static fn (mixed $status): string => strtolower(trim((string) $status)),
+            is_array($statuses) ? $statuses : []
+        )));
+    }
+
+    public static function defaultStatus(): string
+    {
+        $configured = strtolower(trim((string) config('ninjaportal.user.default_status', 'pending')));
+        $statuses = static::statuses();
+
+        if ($configured !== '' && in_array($configured, $statuses, true)) {
+            return $configured;
+        }
+
+        return $statuses[0] ?? 'pending';
+    }
+
+    public static function activeStatus(): string
+    {
+        return in_array('active', static::statuses(), true) ? 'active' : static::defaultStatus();
+    }
+
+    public static function inactiveStatus(): string
+    {
+        return in_array('inactive', static::statuses(), true) ? 'inactive' : static::defaultStatus();
     }
 }

--- a/src/Query/Filters/ApiProductFilter.php
+++ b/src/Query/Filters/ApiProductFilter.php
@@ -15,11 +15,10 @@ class ApiProductFilter extends FilterAbstract
     protected function filterVisibility(Builder $builder, mixed $value): void
     {
         $visibility = strtolower(trim((string) $value));
-        if ($visibility === '' || ! array_key_exists($visibility, ApiProduct::$VISIBILITY)) {
+        if ($visibility === '' || ! in_array($visibility, ApiProduct::visibilities(), true)) {
             return;
         }
 
         $builder->where('visibility', $visibility);
     }
 }
-

--- a/src/Query/Filters/UserFilter.php
+++ b/src/Query/Filters/UserFilter.php
@@ -16,11 +16,10 @@ class UserFilter extends FilterAbstract
     protected function filterStatus(Builder $builder, mixed $value): void
     {
         $status = strtolower(trim((string) $value));
-        if ($status === '' || ! in_array($status, array_values(User::$USER_STATUS), true)) {
+        if ($status === '' || ! in_array($status, User::statuses(), true)) {
             return;
         }
 
         $builder->where('status', $status);
     }
 }
-

--- a/src/Seeders/Demo/ApiProductSeeder.php
+++ b/src/Seeders/Demo/ApiProductSeeder.php
@@ -16,7 +16,7 @@ class ApiProductSeeder extends Seeder
                 'slug' => 'payments-suite',
                 'swagger_url' => 'https://specs.ninjaportal.test/payments-suite.yaml',
                 'apigee_product_id' => 'payments-suite',
-                'visibility' => ApiProduct::$VISIBILITY['public'],
+                'visibility' => 'public',
                 'categories' => ['payments'],
                 'audiences' => ['Retail Developers', 'Partner Integrators'],
                 'ar' => [
@@ -36,7 +36,7 @@ class ApiProductSeeder extends Seeder
                 'slug' => 'usage-analytics',
                 'swagger_url' => 'https://specs.ninjaportal.test/usage-analytics.yaml',
                 'apigee_product_id' => 'usage-analytics',
-                'visibility' => ApiProduct::$VISIBILITY['public'],
+                'visibility' => ApiProduct::defaultVisibility(),
                 'categories' => ['analytics'],
                 'audiences' => ['Retail Developers', 'Internal Teams'],
                 'ar' => [
@@ -56,7 +56,7 @@ class ApiProductSeeder extends Seeder
                 'slug' => 'kyc-compliance',
                 'swagger_url' => 'https://specs.ninjaportal.test/kyc-compliance.yaml',
                 'apigee_product_id' => 'kyc-compliance',
-                'visibility' => ApiProduct::$VISIBILITY['private'],
+                'visibility' => 'private',
                 'categories' => ['compliance', 'analytics'],
                 'audiences' => ['Partner Integrators'],
 

--- a/src/Seeders/Demo/UserSeeder.php
+++ b/src/Seeders/Demo/UserSeeder.php
@@ -16,7 +16,7 @@ class UserSeeder extends Seeder
                 'last_name' => 'Summers',
                 'email' => 'jade.summers@ninjaportal.test',
                 'password' => 'password',
-                'status' => PortalUser::$ACTIVE_STATUS,
+                'status' => PortalUser::activeStatus(),
                 'email_verified_at' => now(),
                 'sync_with_apigee' => false,
                 'custom_attributes' => [
@@ -30,7 +30,7 @@ class UserSeeder extends Seeder
                 'last_name' => 'Diaz',
                 'email' => 'marco.diaz@ninjaportal.test',
                 'password' => 'password',
-                'status' => PortalUser::$ACTIVE_STATUS,
+                'status' => PortalUser::activeStatus(),
                 'email_verified_at' => now()->subDay(),
                 'sync_with_apigee' => true,
                 'custom_attributes' => [
@@ -44,7 +44,7 @@ class UserSeeder extends Seeder
                 'last_name' => 'Nair',
                 'email' => 'priya.nair@ninjaportal.test',
                 'password' => 'password',
-                'status' => PortalUser::$DEFAULT_STATUS,
+                'status' => PortalUser::defaultStatus(),
                 'sync_with_apigee' => false,
                 'custom_attributes' => [
                     'company' => 'Ninja Portal',

--- a/src/Services/UserService.php
+++ b/src/Services/UserService.php
@@ -28,7 +28,7 @@ class UserService extends BaseService implements UserServiceInterface
     protected function mutateDataBeforeCreate(array $data): array
     {
         if (! array_key_exists('status', $data) || $data['status'] === null || $data['status'] === '') {
-            $data['status'] = User::$DEFAULT_STATUS;
+            $data['status'] = User::defaultStatus();
         }
 
         return $data;

--- a/tests/Feature/PortalServiceProviderTest.php
+++ b/tests/Feature/PortalServiceProviderTest.php
@@ -55,4 +55,18 @@ class PortalServiceProviderTest extends TestCase
         $this->assertFalse(method_exists(new \NinjaPortal\Portal\Models\Admin, 'getJWTIdentifier'));
         $this->assertFalse(method_exists(new \NinjaPortal\Portal\Models\Admin, 'getJWTCustomClaims'));
     }
+
+    public function test_user_and_api_product_defaults_can_be_resolved_from_config(): void
+    {
+        config()->set('ninjaportal.user.statuses', ['draft', 'active', 'inactive']);
+        config()->set('ninjaportal.user.default_status', 'draft');
+        config()->set('ninjaportal.api_products.default_visibility', 'private');
+        config()->set('ninjaportal.api_products.storage_disk', 's3');
+
+        $this->assertSame(['draft', 'active', 'inactive'], \NinjaPortal\Portal\Models\User::statuses());
+        $this->assertSame('draft', \NinjaPortal\Portal\Models\User::defaultStatus());
+        $this->assertSame('active', \NinjaPortal\Portal\Models\User::activeStatus());
+        $this->assertSame('private', \NinjaPortal\Portal\Models\ApiProduct::defaultVisibility());
+        $this->assertSame('s3', \NinjaPortal\Portal\Models\ApiProduct::storageDisk());
+    }
 }


### PR DESCRIPTION
## Summary
- move Portal user statuses and default status to config
- move Portal API product default visibility and storage disk to config
- update Portal models, migrations, filters, seeders, and services to resolve these values from config instead of model statics
- add a regression test covering the new config-backed behavior

## Config keys added
- `ninjaportal.user.statuses`
- `ninjaportal.user.default_status`
- `ninjaportal.api_products.default_visibility`
- `ninjaportal.api_products.storage_disk`

## What changed
- `User` now exposes helper methods backed by config:
  - `statuses()`
  - `defaultStatus()`
  - `activeStatus()`
  - `inactiveStatus()`
- `ApiProduct` now exposes helper methods backed by config:
  - `defaultVisibility()`
  - `storageDisk()`
- updated Portal migrations to use the configured defaults for user status and API product visibility
- updated filters and demo seeders to use the new config-backed helpers
- updated `UserService` to default new users to the configured default status

## Why
We noticed some defaults were split between model constants and migrations/services, which made the behavior harder to override consistently. This change makes the selected defaults configurable from one place without changing the public package structure.

## Validation
- `php -l` passed on the touched PHP files
- `composer validate --strict` passed in `backend/packages/portal`
